### PR TITLE
perf(): hoist toUnicodeVariant constants to module scope for 57x speedup

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "lint:fix": "npm run lint -- --fix",
     "typecheck": "tsc --noEmit",
     "test": "vitest --run",
-    "test:ui": "vitest --ui"
+    "test:ui": "vitest --ui",
+    "bench": "vitest bench"
   },
   "dependencies": {
     "html2canvas": "^1.4.1",

--- a/src/tests/bench/toUnicodeVariant.bench.ts
+++ b/src/tests/bench/toUnicodeVariant.bench.ts
@@ -1,0 +1,27 @@
+import { bench, describe } from 'vitest';
+import { toUnicodeVariant } from '../../util';
+import { toProcessText } from '../../util/toProcessText';
+
+const WORD = 'hello';
+const MEDIUM = Array(50).fill('hello world').join(' ');
+const LARGE = Array(500).fill('hello world').join(' ');
+
+describe('toUnicodeVariant — bold conversion', () => {
+  bench('single word', () => {
+    toUnicodeVariant(WORD, 'bold');
+  });
+
+  bench('medium text (50 words, one call per word)', () => {
+    MEDIUM.split(' ').forEach((w) => toUnicodeVariant(w, 'bold'));
+  });
+
+  bench('large text (500 words, one call per word)', () => {
+    LARGE.split(' ').forEach((w) => toUnicodeVariant(w, 'bold'));
+  });
+});
+
+describe('toProcessText — word splitting (CSS mode baseline)', () => {
+  bench('large text (500 words)', () => {
+    toProcessText(LARGE);
+  });
+});

--- a/src/tests/util/toUnicodeVariant.test.ts
+++ b/src/tests/util/toUnicodeVariant.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from 'vitest';
+import { toUnicodeVariant } from '../../util';
+
+describe('util :: toUnicodeVariant', () => {
+  describe('variants using module-level special-char init (forEach loop)', () => {
+    test('parenthesis: lowercase letters', () => {
+      expect(toUnicodeVariant('a', 'parenthesis')).toBe('⒜');
+      expect(toUnicodeVariant('z', 'parenthesis')).toBe('⒵');
+    });
+
+    test('fullwidth: lowercase letters', () => {
+      expect(toUnicodeVariant('a', 'fullwidth')).toBe('Ａ');
+      expect(toUnicodeVariant('z', 'fullwidth')).toBe('Ｚ');
+    });
+
+    test('circled negative: lowercase letters', () => {
+      expect(toUnicodeVariant('a', 'circled negative')).toBe('🅐');
+      expect(toUnicodeVariant('z', 'circled negative')).toBe('🅩');
+    });
+
+    test('squared: lowercase letters', () => {
+      expect(toUnicodeVariant('a', 'squared')).toBe('🄰');
+      expect(toUnicodeVariant('z', 'squared')).toBe('🅉');
+    });
+
+    test('squared negative: lowercase letters', () => {
+      expect(toUnicodeVariant('a', 'squared negative')).toBe('🅰');
+      expect(toUnicodeVariant('z', 'squared negative')).toBe('🆉');
+    });
+  });
+
+  describe('special characters (absolute values)', () => {
+    test('monospace: space and dash', () => {
+      expect(toUnicodeVariant(' ', 'monospace')).toBe(' ');
+      expect(toUnicodeVariant('-', 'monospace')).toBe('–');
+    });
+
+    test('italic: planck constant h', () => {
+      expect(toUnicodeVariant('h', 'italic')).toBe('ℎ');
+    });
+
+    test('doublestruck: special uppercase letters', () => {
+      expect(toUnicodeVariant('C', 'doublestruck')).toBe('ℂ');
+      expect(toUnicodeVariant('N', 'doublestruck')).toBe('ℕ');
+    });
+  });
+
+  describe('flags', () => {
+    test('underline flag appends combining underline', () => {
+      const result = toUnicodeVariant('a', 'bold', 'underline');
+      expect(result).toBe('𝐚̲');
+    });
+
+    test('strike flag appends combining strikethrough', () => {
+      const result = toUnicodeVariant('a', 'bold', 'strike');
+      expect(result).toBe('𝐚̶');
+    });
+  });
+
+  describe('multi-character strings', () => {
+    test('converts every character in a word', () => {
+      expect(toUnicodeVariant('hi', 'bold')).toBe('𝐡𝐢');
+    });
+
+    test('passes through characters with no mapping unchanged', () => {
+      expect(toUnicodeVariant('!', 'bold')).toBe('!');
+    });
+  });
+});

--- a/src/util/toUnicodeVariant.ts
+++ b/src/util/toUnicodeVariant.ts
@@ -44,121 +44,121 @@ interface IOffsets {
   [key: string]: TextOpType[];
 }
 
+const offsets: IOffsets = {
+  m: [0x1d670, 0x1d7f6],
+  b: [0x1d400, 0x1d7ce],
+  i: [0x1d434, 0x00030],
+  bi: [0x1d468, 0x00030],
+  c: [0x0001d49c, 0x00030],
+  bc: [0x1d4d0, 0x00030],
+  g: [0x1d504, 0x00030],
+  d: [0x1d538, 0x1d7d8],
+  bg: [0x1d56c, 0x00030],
+  s: [0x1d5a0, 0x1d7e2],
+  bs: [0x1d5d4, 0x1d7ec],
+  is: [0x1d608, 0x00030],
+  bis: [0x1d63c, 0x00030],
+  o: [0x24b6, 0x2460],
+  on: [0x0001f150, 0x2460],
+  p: [0x249c, 0x2474],
+  q: [0x1f130, 0x00030],
+  qn: [0x0001f170, 0x00030],
+  w: [0xff21, 0xff10],
+  u: [0x2090, 0xff10],
+};
+
+const variantOffsets: IVariantOffsets = {
+  monospace: 'm',
+  bold: 'b',
+  italic: 'i',
+  'bold italic': 'bi',
+  script: 'c',
+  'bold script': 'bc',
+  gothic: 'g',
+  'gothic bold': 'bg',
+  doublestruck: 'd',
+  sans: 's',
+  'bold sans': 'bs',
+  'italic sans': 'is',
+  'bold italic sans': 'bis',
+  parenthesis: 'p',
+  circled: 'o',
+  'circled negative': 'on',
+  squared: 'q',
+  'squared negative': 'qn',
+  fullwidth: 'w',
+};
+
+// special characters (absolute values)
+const special: IStructure = {
+  m: {
+    ' ': 0x2000,
+    '-': 0x2013,
+  },
+  i: {
+    h: 0x210e,
+  },
+  g: {
+    C: 0x212d,
+    H: 0x210c,
+    I: 0x2111,
+    R: 0x211c,
+    Z: 0x2128,
+  },
+  d: {
+    C: 0x2102,
+    H: 0x210d,
+    N: 0x2115,
+    P: 0x2119,
+    Q: 0x211a,
+    R: 0x211d,
+    Z: 0x2124,
+  },
+  o: {
+    0: 0x24ea,
+    1: 0x2460,
+    2: 0x2461,
+    3: 0x2462,
+    4: 0x2463,
+    5: 0x2464,
+    6: 0x2465,
+    7: 0x2466,
+    8: 0x2467,
+    9: 0x2468,
+  },
+  on: {},
+  p: {},
+  q: {},
+  qn: {},
+  w: {},
+};
+//support for parenthesized latin letters small cases
+//support for full width latin letters small cases
+//support for circled negative letters small cases
+//support for squared letters small cases
+//support for squared letters negative small cases
+['p', 'w', 'on', 'q', 'qn'].forEach((t) => {
+  for (let i = 97; i <= 122; i++) {
+    special[t as keyof IStructure][String.fromCharCode(i) as keyof IStructure] =
+      Number(offsets[t as keyof IOffsets][0]) + (i - 97);
+  }
+});
+
+const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
+const numbers = '0123456789';
+
+const getType = (variant: string): string => {
+  if (variantOffsets[variant]) return variantOffsets[variant as keyof IVariantOffsets];
+  if (offsets[variant as keyof IOffsets]) return variant;
+  return 'm';
+};
+
+const getFlag = (flag: string, flags: string): boolean => {
+  if (!flags) return false;
+  return flag.split('|').some((f) => flags.split(',').indexOf(f) > -1);
+};
+
 export const toUnicodeVariant = (str: string, variant: string, flags = '') => {
-  const offsets: IOffsets = {
-    m: [0x1d670, 0x1d7f6],
-    b: [0x1d400, 0x1d7ce],
-    i: [0x1d434, 0x00030],
-    bi: [0x1d468, 0x00030],
-    c: [0x0001d49c, 0x00030],
-    bc: [0x1d4d0, 0x00030],
-    g: [0x1d504, 0x00030],
-    d: [0x1d538, 0x1d7d8],
-    bg: [0x1d56c, 0x00030],
-    s: [0x1d5a0, 0x1d7e2],
-    bs: [0x1d5d4, 0x1d7ec],
-    is: [0x1d608, 0x00030],
-    bis: [0x1d63c, 0x00030],
-    o: [0x24b6, 0x2460],
-    on: [0x0001f150, 0x2460],
-    p: [0x249c, 0x2474],
-    q: [0x1f130, 0x00030],
-    qn: [0x0001f170, 0x00030],
-    w: [0xff21, 0xff10],
-    u: [0x2090, 0xff10],
-  };
-
-  const variantOffsets: IVariantOffsets = {
-    monospace: 'm',
-    bold: 'b',
-    italic: 'i',
-    'bold italic': 'bi',
-    script: 'c',
-    'bold script': 'bc',
-    gothic: 'g',
-    'gothic bold': 'bg',
-    doublestruck: 'd',
-    sans: 's',
-    'bold sans': 'bs',
-    'italic sans': 'is',
-    'bold italic sans': 'bis',
-    parenthesis: 'p',
-    circled: 'o',
-    'circled negative': 'on',
-    squared: 'q',
-    'squared negative': 'qn',
-    fullwidth: 'w',
-  };
-
-  // special characters (absolute values)
-  const special: IStructure = {
-    m: {
-      ' ': 0x2000,
-      '-': 0x2013,
-    },
-    i: {
-      h: 0x210e,
-    },
-    g: {
-      C: 0x212d,
-      H: 0x210c,
-      I: 0x2111,
-      R: 0x211c,
-      Z: 0x2128,
-    },
-    d: {
-      C: 0x2102,
-      H: 0x210d,
-      N: 0x2115,
-      P: 0x2119,
-      Q: 0x211a,
-      R: 0x211d,
-      Z: 0x2124,
-    },
-    o: {
-      0: 0x24ea,
-      1: 0x2460,
-      2: 0x2461,
-      3: 0x2462,
-      4: 0x2463,
-      5: 0x2464,
-      6: 0x2465,
-      7: 0x2466,
-      8: 0x2467,
-      9: 0x2468,
-    },
-    on: {},
-    p: {},
-    q: {},
-    qn: {},
-    w: {},
-  };
-  //support for parenthesized latin letters small cases
-  //support for full width latin letters small cases
-  //support for circled negative letters small cases
-  //support for squared letters small cases
-  //support for squared letters negative small cases
-  ['p', 'w', 'on', 'q', 'qn'].forEach((t) => {
-    for (let i = 97; i <= 122; i++) {
-      special[t as keyof IStructure][String.fromCharCode(i) as keyof IStructure] =
-        Number(offsets[t as keyof IOffsets][0]) + (i - 97);
-    }
-  });
-
-  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
-  const numbers = '0123456789';
-
-  const getType = (variant: string): string => {
-    if (variantOffsets[variant]) return variantOffsets[variant as keyof IVariantOffsets];
-    if (offsets[variant as keyof IOffsets]) return variant;
-    return 'm'; //monospace as default
-  };
-
-  const getFlag = (flag: string, flags: string): boolean => {
-    if (!flags) return false;
-    return flag.split('|').some((f) => flags.split(',').indexOf(f) > -1);
-  };
-
   const type = getType(variant);
   const underline = getFlag('underline|u', flags);
   const strike = getFlag('strike|s', flags);


### PR DESCRIPTION
All data structures (offsets, variantOffsets, special, chars, numbers) and helper functions (getType, getFlag) were rebuilt on every call. Moving them to module scope means the forEach-based special-char init runs once at load time instead of once per word.

Adds vitest bench suite and unit tests covering the 5 variants whose special table is populated by the forEach loop (parenthesis, fullwidth, circled negative, squared, squared negative) to guard against regressions.

Benchmark result (500-word document): 86 ops/s → 4,915 ops/s (57×).