### PR TITLE
fix(ci): restore git state after npm ci before npm version

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Install npm packages
         run: npm ci
 
+      - name: Restore any files dirtied by npm ci
+        run: git restore .
+
       - name: Setup Git
         run: |
           git config user.name 'Lucian Bot'


### PR DESCRIPTION
npm ci can normalize package-lock.json leaving the working tree dirty, which causes `npm version` to abort with "Git working directory not clean". Run `git restore .` after install to discard any such changes.