### PR TITLE
fix(ci): add npm cache and path filter to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,16 @@
 name: Build and Deploy
-on: 
+on:
   push:
     branches:
       - main
+    paths:
+      - 'src/**'
+      - 'public/**'
+      - 'index.html'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'vite.config.*'
+      - 'tsconfig*'
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
@@ -15,6 +23,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22'
+          cache: 'npm'
 
       - name: Install and Build 🔧 # This example project is built using npm and outputs the result to the 'build' folder. Replace with the commands required to build your project, or remove this step entirely if your site is pre-built.
         run: |


### PR DESCRIPTION
- Add cache: 'npm' to setup-node — consistent with all other workflows, avoids a full reinstall on every deploy
- Add paths filter so deploys only trigger on changes to source files, not on workflow/doc/config-only commits