### PR TITLE
fix(ci): rewrite create-release workflow — remove npm publish, fix bugs

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -6,32 +6,15 @@ on:
 name: Create Release
 
 jobs:
-  publish:
-    name: Publish to npm
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-          cache: 'npm'
-      - name: Publish
-        run: |
-          npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
-          npm ci
-          npm run build
-          npm publish
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-
   create-github-release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
-    needs: publish
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
-        uses: actions/setup-node@v4
+        uses: actions/checkout@v4
       - name: Create Release
-        run: gh release create ${{ github.ref }} --generate-notes
+        run: gh release create ${{ github.ref_name }} --generate-notes
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Remove npm publish job: package.json has "private": true so npm publish always fails, which blocked the GitHub Release from ever being created
- Fix copy-paste bug: checkout step was using actions/setup-node@v4 instead of actions/checkout@v4
- Remove needs: publish which blocked the release job on the failing publish
- Fix github.ref → github.ref_name (ref gives refs/tags/v0.5.0, ref_name gives the clean v0.5.0 that gh release create expects)
- Add permissions: contents: write required to create GitHub Releases