### PR TITLE
fix(ci): enable tests in Node.js CI, add npm cache, split steps

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,6 +1,3 @@
-# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
-
 name: Node.js CI
 
 on:
@@ -11,7 +8,6 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
@@ -20,8 +16,10 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: '22'
-    - name: Install Dependencies
-      run: npm ci && npm run build
-
-#    - name: Test
-#      run: npm ci && npm test
+        cache: 'npm'
+    - name: Install dependencies
+      run: npm ci
+    - name: Build
+      run: npm run build
+    - name: Test
+      run: npm test


### PR DESCRIPTION
- Enable Test step — vitest is fully configured and 19 tests pass
- Add cache: 'npm' to match all other workflows
- Split single 'npm ci && npm run build' into discrete Install, Build, and Test steps for clearer output and faster failure attribution
- Remove stale boilerplate comments