### PR TITLE
fix(ci): restore PR approach, remove npm ci and setup-node

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,5 +1,5 @@
 # Manually triggered version bump.
-# Bumps package.json + package-lock.json, pushes directly to main,
+# Bumps package.json + package-lock.json, opens a PR to merge into main,
 # then pushes the tag (triggers create-release.yml).
 
 name: Bump version
@@ -21,6 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - name: Check out source
@@ -34,8 +35,22 @@ jobs:
       - name: Bump version
         run: npm version ${{ github.event.inputs.version }}
 
-      - name: Push version bump to main
-        run: git push origin HEAD:main
+      - name: Push version bump branch
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          git checkout -b chore/bump-v${VERSION}
+          git push origin chore/bump-v${VERSION}
+
+      - name: Open PR for version bump
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          gh pr create \
+            --title "chore: bump version to v${VERSION}" \
+            --body "Automated version bump triggered by the Bump version workflow." \
+            --base main \
+            --head "chore/bump-v${VERSION}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push tag (triggers create-release workflow)
         run: git push origin --tags


### PR DESCRIPTION
- Restore PR branch + gh pr create flow (branch protection blocks direct push)
- Remove npm ci: not needed, npm version only edits JSON files
- Remove cache: 'npm' and setup-node: pointless without an install step