### PR TITLE
docs: add Performance section with 57x speedup commit link

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,11 @@ Open-source **React**, **Vite**, **Tailwind CSS** & **TypeScript** tool that acc
 | Dark mode                                         | Light/dark theme toggle with `localStorage` persistence | :heavy_check_mark:
 | File import (TXT, DOCX, PDF, EPUB)               | Import files via advanced mode toggle — parsed client-side, files never leave the browser | :heavy_check_mark:
 | Bionic EPUB export                                | Export a bionic-formatted `.epub` file with `<b>` fixation points applied to all HTML chapters | :heavy_check_mark:
+| [57× Unicode speedup][perf-commit]                | Hoist `toUnicodeVariant` constants to module scope — data structures built once at load time instead of once per word | :heavy_check_mark:
 | Show characters                                   | Display Characters after textarea | backlog
 | Increase fonts                                   | Create functionality to increase/descrease fonts size | backlog
+
+[perf-commit]: https://github.com/crisanlucid/primusread/commit/1bd266d8f973ce9d83bfb016e0e1405f48ccf197
 
 
 ### How to Run
@@ -39,6 +42,17 @@ Open-source **React**, **Vite**, **Tailwind CSS** & **TypeScript** tool that acc
 ```bash
 npm install && npm run dev
 ```
+
+## Performance
+
+Unicode mode (`toUnicodeVariant`) was originally rebuilding all data structures on every call. [Hoisting constants to module scope][perf-commit] reduced the per-call overhead to zero, yielding a **57× throughput improvement** on a 500-word document (86 ops/s → 4,915 ops/s).
+
+| Mode | 500-word document |
+|---|---|
+| CSS mode (default) | ~15,700 ops/s |
+| Unicode mode (after fix) | ~4,900 ops/s |
+
+Run the benchmark yourself: `npm run bench`
 
 ## PDF functionality
 ![Save text as PDF file](./src/assets/primusread_pdf_export.PNG)

--- a/README.md
+++ b/README.md
@@ -81,47 +81,7 @@ Pull requests are welcome :)
 
 ---
 
-## Release Flow
-
-Step-by-step guide for releasing a new version.
-
-### 1. Develop on a feature branch
-
-```bash
-git checkout -b feature/my-feature
-# ... make changes ...
-git add <files>
-git commit -m "feat: my feature"
-git push origin feature/my-feature
-```
-
-### 2. Open a Pull Request → merge into `main`
-
-Opening a PR triggers:
-- **Node.js CI** — installs deps, builds, runs tests
-- **CodeQL** — security scan
-
-Merging into `main` additionally triggers:
-- **Build and Deploy** — deploys to GitHub Pages (only when source files change)
-
-### 3. Bump the version
-
-Go to **Actions → Bump version → Run workflow** and choose:
-- `patch` → bug fixes / small improvements (0.5.0 → 0.5.1)
-- `minor` → new features, backwards compatible (0.5.0 → 0.6.0)
-- `major` → breaking changes (0.5.0 → 1.0.0)
-
-This workflow will:
-- Bump `package.json` + `package-lock.json` version
-- Create a git tag (e.g. `v0.6.0`) and push it
-- Open a PR named `chore: bump version to vX.X.X`
-
-### 4. Merge the version bump PR
-
-Merge the `chore: bump version to vX.X.X` PR into `main`. This automatically:
-- Runs CI (install, build, test)
-- Deploys to GitHub Pages
-- **Creates a GitHub Release** with auto-generated notes
+For the step-by-step release process see [ReleaseFlow.md](./ReleaseFlow.md).
 
 ---
 

--- a/ReleaseFlow.md
+++ b/ReleaseFlow.md
@@ -1,0 +1,41 @@
+# Release Flow
+
+Step-by-step guide for releasing a new version.
+
+### 1. Develop on a feature branch
+
+```bash
+git checkout -b feature/my-feature
+# ... make changes ...
+git add <files>
+git commit -m "feat: my feature"
+git push origin feature/my-feature
+```
+
+### 2. Open a Pull Request → merge into `main`
+
+Opening a PR triggers:
+- **Node.js CI** — installs deps, builds, runs tests
+- **CodeQL** — security scan
+
+Merging into `main` additionally triggers:
+- **Build and Deploy** — deploys to GitHub Pages (only when source files change)
+
+### 3. Bump the version
+
+Go to **Actions → Bump version → Run workflow** and choose:
+- `patch` → bug fixes / small improvements (0.5.0 → 0.5.1)
+- `minor` → new features, backwards compatible (0.5.0 → 0.6.0)
+- `major` → breaking changes (0.5.0 → 1.0.0)
+
+This workflow will:
+- Bump `package.json` + `package-lock.json` version
+- Create a git tag (e.g. `v0.6.0`) and push it
+- Open a PR named `chore: bump version to vX.X.X`
+
+### 4. Merge the version bump PR
+
+Merge the `chore: bump version to vX.X.X` PR into `main`. This automatically:
+- Runs CI (install, build, test)
+- Deploys to GitHub Pages
+- **Creates a GitHub Release** with auto-generated notes


### PR DESCRIPTION
## Summary

- Add **Performance** section to README with a table comparing CSS mode vs Unicode mode throughput on a 500-word document
- Add `[57× Unicode speedup]` row to the roadmap table — both link directly to [`1bd266d`](https://github.com/crisanlucid/primusread/commit/1bd266d8f973ce9d83bfb016e0e1405f48ccf197) where the fix is documented with before/after benchmark numbers
- Add `npm run bench` call-to-action so readers can reproduce the result

🤖 Generated with [Claude Code](https://claude.com/claude-code)